### PR TITLE
Persist queue open status across restarts

### DIFF
--- a/commands/queueManagement.js
+++ b/commands/queueManagement.js
@@ -4,12 +4,14 @@ import { state } from '../constants.js';
 
 async function handleOpenCommand(channel, tags, client, io) {
   state.queue_open = true;
+  await settings_db.set('queue_open', true);
   abbadabbabotSay(channel, client, tags, 'formally announce the opening of the queue to the chat');
   io.emit('new_turn', `Queue Just Opened`);
 }
 
 async function handleCloseCommand(channel, tags, client, io) {
   state.queue_open = false;
+  await settings_db.set('queue_open', false);
   abbadabbabotSay(channel, client, tags, 'formally announce the closing of the queue to the chat');
   io.emit('new_turn', `Queue Closed`);
 }

--- a/constants.js
+++ b/constants.js
@@ -1,16 +1,24 @@
 import dotenv from 'dotenv';
+import jsoning from 'jsoning';
 import { fileURLToPath } from 'url';
-import { dirname } from 'path';
+import { dirname, join } from 'path';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
 dotenv.config();
 
+const settings_db = new jsoning(join(__dirname, 'db/queue_settings.json'));
+let queueOpen = await settings_db.get('queue_open');
+if (queueOpen === undefined) {
+  queueOpen = false;
+  await settings_db.set('queue_open', queueOpen);
+}
+
 export const state = {
   current_turn: "None... yet",
   end_time: 1708317900,
-  queue_open: false,
+  queue_open: queueOpen,
   firsts_first: true,
   ai_enabled: true,
   death_count: 0,

--- a/db/queue_settings.json
+++ b/db/queue_settings.json
@@ -1,1 +1,12 @@
-{"last_turn_type":false,"deeze_nutz":2650,"turn_count":2501,"youtubes_watched":74,"notification":"<h3><span style=\"font-family: helvetica, arial, sans-serif; background-color: #f1c40f; font-size: 24pt;\">Sexy Mustard Sandwich: 5 | Skooty: 2 | Josh: 5</span><br /><span style=\"font-family: helvetica, arial, sans-serif;\"><span style=\"background-color: #f1c40f;\"><span style=\"text-decoration: line-through;\">Propose and get a yes&nbsp;</span><br /></span><span style=\"background-color: #f1c40f;\">Ask someone to suck cheeto dust off fingers</span></span><br /><span style=\"text-decoration: line-through;\"><span style=\"font-family: helvetica, arial, sans-serif; background-color: #f1c40f;\">Nickelodeon cartoon avatar</span></span><br /><span style=\"font-family: helvetica, arial, sans-serif;\"><span style=\"background-color: #f1c40f;\">Giant Nose with boogers<br /></span><span style=\"background-color: #f1c40f;\">Sing with someone</span></span></h3>","subsTracker":1057,"bitsTracker":80612,"donationsTracker":2119.5205564735597,"completedSpins":3}
+{
+  "last_turn_type": false,
+  "deeze_nutz": 2650,
+  "turn_count": 2501,
+  "youtubes_watched": 74,
+  "notification": "<h3><span style=\"font-family: helvetica, arial, sans-serif; background-color: #f1c40f; font-size: 24pt;\">Sexy Mustard Sandwich: 5 | Skooty: 2 | Josh: 5</span><br /><span style=\"font-family: helvetica, arial, sans-serif;\"><span style=\"background-color: #f1c40f;\"><span style=\"text-decoration: line-through;\">Propose and get a yes&nbsp;</span><br /></span><span style=\"background-color: #f1c40f;\">Ask someone to suck cheeto dust off fingers</span></span><br /><span style=\"text-decoration: line-through;\"><span style=\"font-family: helvetica, arial, sans-serif; background-color: #f1c40f;\">Nickelodeon cartoon avatar</span></span><br /><span style=\"font-family: helvetica, arial, sans-serif;\"><span style=\"background-color: #f1c40f;\">Giant Nose with boogers<br /></span><span style=\"background-color: #f1c40f;\">Sing with someone</span></span></h3>",
+  "subsTracker": 1057,
+  "bitsTracker": 80612,
+  "donationsTracker": 2119.5205564735597,
+  "completedSpins": 3,
+  "queue_open": false
+}


### PR DESCRIPTION
## Summary
- load saved `queue_open` setting on startup
- save queue open/close state in database

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6850fdeee2f88326a2b73381557cb59b